### PR TITLE
Propagate temporal context options in prediction pipeline

### DIFF
--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -605,6 +605,17 @@ def predict_once(cfg: PipelineConfig | Dict[str, Any]) -> str:
     model_cfg["static_proj_dim"] = static_proj_dim
     model_cfg["static_layernorm"] = static_layernorm
 
+    use_zero_mean_context = bool(model_cfg.get("use_zero_mean_context", False))
+    context_rank = int(model_cfg.get("context_rank", 0))
+    if context_rank < 0:
+        context_rank = 0
+    context_scale = float(model_cfg.get("context_scale", 1e-2))
+    use_constant_context_bias = bool(model_cfg.get("use_constant_context_bias", False))
+    model_cfg["use_zero_mean_context"] = use_zero_mean_context
+    model_cfg["context_rank"] = context_rank
+    model_cfg["context_scale"] = context_scale
+    model_cfg["use_constant_context_bias"] = use_constant_context_bias
+
     model = TimesNet(
         input_len=input_len,
         pred_len=pred_len,
@@ -626,6 +637,10 @@ def predict_once(cfg: PipelineConfig | Dict[str, Any]) -> str:
         id_embed_dim=id_embed_dim,
         static_proj_dim=static_proj_dim,
         static_layernorm=static_layernorm,
+        use_zero_mean_context=use_zero_mean_context,
+        context_rank=context_rank,
+        context_scale=context_scale,
+        use_constant_context_bias=use_constant_context_bias,
     ).to(device)
     # Lazily construct layers by mirroring the training warm-up.
     warmup_kwargs: Dict[str, torch.Tensor] = {}


### PR DESCRIPTION
## Summary
- read the low-rank temporal context configuration in `predict.py`
- pass the context arguments when building `TimesNet` during inference to match training checkpoints

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db72fb4f348328a8324797e3c56292